### PR TITLE
chore: pull upstream fix on unix socket error

### DIFF
--- a/etc/gunicorn.py
+++ b/etc/gunicorn.py
@@ -14,12 +14,12 @@
 
 import multiprocessing
 
-bind = "127.0.0.1:9998"
+bind = "unix:/var/lib/skyline/skyline.sock"
+reuse_port = False
 workers = (1 + multiprocessing.cpu_count()) // 2
 worker_class = "uvicorn.workers.UvicornWorker"
 timeout = 300
 keepalive = 5
-reuse_port = True
 proc_name = "skyline"
 
 logconfig_dict = {


### PR DESCRIPTION
### What type of PR is this?

- chore

### What this PR does / why we need it

- Pull the upstream fix on unix socket opening error

### Which issue(s) this PR fixes

### Special notes for your reviewer

### Additional documentation

> Operation not supported" errors: Recent Linux kernel versions (e.g., 6.1.124 and newer) have explicitly restricted SO_REUSEPORT to AF_INET and AF_INET6 sockets. Attempting to set SO_REUSEPORT on an AF_UNIX socket will result in an OSError: [Errno 95] Operation not supported (EOPNOTSUPP). Gunicorn, like other applications, will encounter this error if reuse_port is set to True for Unix socket bindings.

Fixed by https://github.com/openstack/skyline-apiserver/commit/65673a38f330dd79eb7bcbfd97a8f0910bf15156

Upstream bug report https://bugs.launchpad.net/skyline-apiserver/+bug/2111808
